### PR TITLE
override linear token based on verified user id

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,8 @@ type config struct {
 	// External URI to /api
 	APIPrefix string `yaml:"api_prefix"`
 
-	LinearToken string `yaml:"linear_token"`
+	LinearToken         string            `yaml:"linear_token"`
+	LinearTokenOverride map[string]string `yaml:"linear_token_override"`
 
 	APIServerURLs map[string]string `yaml:"api_server_url"`
 


### PR DESCRIPTION
this will allow internal users to set their own linear token so issues show up as created by them instead of issue-bot.

(code written entirely by cursor composer)

later explore createAsUser: https://developers.linear.app/docs/oauth/oauth-actor-authorization